### PR TITLE
Added sleep to prevent run duplicates command

### DIFF
--- a/bin/tssh
+++ b/bin/tssh
@@ -64,7 +64,7 @@ if [[ $REAL -eq 1 ]]; then
 	for SERVER in `cat /tmp/tssh_servers`; do
 		if [[ $DRY -ne 1 ]]; then
 			sleep 0.1
-			echo "ssh $SERVER" > /tmp/bash-rcfilie
+			echo "ssh $SERVER" > /tmp/bash-rcfile
 			tmux splitw "bash --rcfile /tmp/bash-rcfile"
 			tmux select-layout tiled
 		else


### PR DESCRIPTION
We were often experiencing duplicate server to be run.
The problem is that the time tmux launch a new window and run the file (rcfile), that file is overwritten by the next server in the list. (the for loop go faster than the I/O read)
